### PR TITLE
Add RSS feed generation for blog posts

### DIFF
--- a/jobs/rss.yaml
+++ b/jobs/rss.yaml
@@ -1,0 +1,8 @@
+type: rss
+options:
+  src_path: blog
+  blog_base_url: /blog
+  base_url: https://archeybarrell.co.uk
+  output_path: /feed.xml
+  title: Archey Barrell's Blog
+  description: Blog posts from Archey Barrell

--- a/src/BlogLoader.php
+++ b/src/BlogLoader.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Website;
+
+use Mni\FrontYAML\Parser;
+
+class BlogLoader
+{
+    private Parser $parser;
+
+    public function __construct()
+    {
+        $this->parser = new Parser();
+    }
+
+    public function loadBlogs(string $dir): array
+    {
+        $files = scandir($dir);
+        $blogs = [];
+
+        foreach ($files as $file) {
+            if ($file == "." || $file == "..") {
+                continue;
+            }
+
+            $blog = $this->parseBlog($dir . DIRECTORY_SEPARATOR . $file);
+            $name = basename($file, ".md");
+            $blogs[$name] = $blog;
+        }
+
+        return $blogs;
+    }
+
+    public function parseBlog(string $file)
+    {
+        $content = file_get_contents($file);
+        return $this->parser->parse($content);
+    }
+}

--- a/src/Job/BlogJob.php
+++ b/src/Job/BlogJob.php
@@ -3,24 +3,24 @@
 namespace Website\Job;
 
 use Twig\Environment;
-use Mni\FrontYAML\Parser;
+use Website\BlogLoader;
 
 class BlogJob implements JobInterface
 {
     private array $options;
     private Environment $twig;
-    private Parser $parser;
+    private BlogLoader $blogLoader;
 
     public function __construct(Environment $twig, array $options)
     {
         $this->twig = $twig;
         $this->options = $options;
-        $this->parser = new Parser();
+        $this->blogLoader = new BlogLoader();
     }
 
     public function run(JobCallbackInterface $cb): void
     {
-        $blogs = $this->loadBlogs();
+        $blogs = $this->blogLoader->loadBlogs($this->options["src_path"]);
         $this->renderBlogs($cb, $blogs);
         $this->renderIndex($cb, $blogs);
     }
@@ -73,31 +73,5 @@ class BlogJob implements JobInterface
         ]);
 
         $cb->AddPage($base_url . "/index.html", $content);
-    }
-
-    public function loadBlogs()
-    {
-        $dir = $this->options["src_path"];
-        $file = scandir($dir);
-        $blogs = [];
-        foreach ($file as $file) {
-            if ($file == "." || $file == "..") {
-                continue;
-            }
-
-            $blog = $this->parseBlog($dir . DIRECTORY_SEPARATOR . $file);
-
-            $name = basename($file, ".md");
-            $blogs[$name] = $blog;
-        }
-
-        return $blogs;
-    }
-
-    public function parseBlog($file)
-    {
-        $content = file_get_contents($file);
-        $parsed = $this->parser->parse($content);
-        return $parsed;
     }
 }

--- a/src/Job/JobFactory.php
+++ b/src/Job/JobFactory.php
@@ -24,6 +24,8 @@ class JobFactory
                 return new BlogJob($this->twig, $options);
             case "error_pages":
                 return new ErrorPagesJob($this->twig, $options);
+            case "rss":
+                return new RssJob($this->twig, $options);
             default:
                 throw new \InvalidArgumentException("Unknown page type: $type");
         }

--- a/src/Job/RssJob.php
+++ b/src/Job/RssJob.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Website\Job;
+
+use Twig\Environment;
+use Mni\FrontYAML\Parser;
+
+class RssJob implements JobInterface
+{
+    private array $options;
+    private Environment $twig;
+    private Parser $parser;
+
+    public function __construct(Environment $twig, array $options)
+    {
+        $this->twig = $twig;
+        $this->options = $options;
+        $this->parser = new Parser();
+    }
+
+    public function run(JobCallbackInterface $cb): void
+    {
+        $blogs = $this->loadBlogs();
+        $this->renderFeed($cb, $blogs);
+    }
+
+    public function renderFeed(JobCallbackInterface $cb, array $blogs): void
+    {
+        $items = [];
+        $baseUrl = $this->options["base_url"] ?? "";
+        $blogBaseUrl = $this->options["blog_base_url"] ?? "/blog";
+
+        foreach ($blogs as $name => $blog) {
+            $metadata = $blog->getYAML();
+            $url = $blogBaseUrl . "/posts/" . $name . ".html";
+
+            $items[] = [
+                "title" => $metadata["title"],
+                "author" => $metadata["author"] ?? "",
+                "url" => $url,
+                "published_at" => strtotime($metadata["published_at"]),
+                "content" => $blog->getContent(),
+            ];
+        }
+
+        usort(
+            $items,
+            fn($a, $b) => $b["published_at"] <=> $a["published_at"],
+        );
+
+        $content = $this->twig->render("blog/feed.xml.twig", [
+            "items" => $items,
+            "base_url" => $baseUrl,
+            "title" => $this->options["title"] ?? "Blog",
+            "description" => $this->options["description"] ?? "",
+        ]);
+
+        $cb->AddPage($this->options["output_path"] ?? "/feed.xml", $content);
+    }
+
+    public function loadBlogs()
+    {
+        $dir = $this->options["src_path"];
+        $files = scandir($dir);
+        $blogs = [];
+
+        foreach ($files as $file) {
+            if ($file == "." || $file == "..") {
+                continue;
+            }
+
+            $blog = $this->parseBlog($dir . DIRECTORY_SEPARATOR . $file);
+            $name = basename($file, ".md");
+            $blogs[$name] = $blog;
+        }
+
+        return $blogs;
+    }
+
+    public function parseBlog($file)
+    {
+        $content = file_get_contents($file);
+        $parsed = $this->parser->parse($content);
+        return $parsed;
+    }
+}

--- a/src/Job/RssJob.php
+++ b/src/Job/RssJob.php
@@ -38,15 +38,12 @@ class RssJob implements JobInterface
                 "title" => $metadata["title"],
                 "author" => $metadata["author"] ?? "",
                 "url" => $url,
-                "published_at" => strtotime($metadata["published_at"]),
+                "published_at" => $metadata["published_at"],
                 "content" => $blog->getContent(),
             ];
         }
 
-        usort(
-            $items,
-            fn($a, $b) => $b["published_at"] <=> $a["published_at"],
-        );
+        usort($items, fn($a, $b) => $b["published_at"] <=> $a["published_at"]);
 
         $content = $this->twig->render("blog/feed.xml.twig", [
             "items" => $items,

--- a/src/Job/RssJob.php
+++ b/src/Job/RssJob.php
@@ -3,24 +3,24 @@
 namespace Website\Job;
 
 use Twig\Environment;
-use Mni\FrontYAML\Parser;
+use Website\BlogLoader;
 
 class RssJob implements JobInterface
 {
     private array $options;
     private Environment $twig;
-    private Parser $parser;
+    private BlogLoader $blogLoader;
 
     public function __construct(Environment $twig, array $options)
     {
         $this->twig = $twig;
         $this->options = $options;
-        $this->parser = new Parser();
+        $this->blogLoader = new BlogLoader();
     }
 
     public function run(JobCallbackInterface $cb): void
     {
-        $blogs = $this->loadBlogs();
+        $blogs = $this->blogLoader->loadBlogs($this->options["src_path"]);
         $this->renderFeed($cb, $blogs);
     }
 
@@ -56,31 +56,5 @@ class RssJob implements JobInterface
         ]);
 
         $cb->AddPage($this->options["output_path"] ?? "/feed.xml", $content);
-    }
-
-    public function loadBlogs()
-    {
-        $dir = $this->options["src_path"];
-        $files = scandir($dir);
-        $blogs = [];
-
-        foreach ($files as $file) {
-            if ($file == "." || $file == "..") {
-                continue;
-            }
-
-            $blog = $this->parseBlog($dir . DIRECTORY_SEPARATOR . $file);
-            $name = basename($file, ".md");
-            $blogs[$name] = $blog;
-        }
-
-        return $blogs;
-    }
-
-    public function parseBlog($file)
-    {
-        $content = file_get_contents($file);
-        $parsed = $this->parser->parse($content);
-        return $parsed;
     }
 }

--- a/templates/abstract.html.twig
+++ b/templates/abstract.html.twig
@@ -6,6 +6,7 @@
   <link rel="shortcut icon" href="/favicon/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
   <link rel="manifest" href="/favicon/site.webmanifest" />
+  <link rel="alternate" type="application/rss+xml" title="Archey Barrell's Blog" href="/feed.xml" />
   <link rel="stylesheet" href="/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="">

--- a/templates/blog/feed.xml.twig
+++ b/templates/blog/feed.xml.twig
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ title }}</title>
+    <link>{{ base_url }}</link>
+    <description>{{ description }}</description>
+    <atom:link href="{{ base_url }}/feed.xml" rel="self" type="application/rss+xml"/>
+    <language>en-us</language>
+    <lastBuildDate>{{ "now"|date("D, d M Y H:i:s O") }}</lastBuildDate>
+{% for item in items %}
+    <item>
+      <title>{{ item.title|e }}</title>
+      <link>{{ base_url }}{{ item.url }}</link>
+      <guid>{{ base_url }}{{ item.url }}</guid>
+      <pubDate>{{ item.published_at|date("D, d M Y H:i:s O") }}</pubDate>
+{% if item.author %}
+      <author>{{ item.author|e }}</author>
+{% endif %}
+      <description><![CDATA[{{ item.content|raw }}]]></description>
+    </item>
+{% endfor %}
+  </channel>
+</rss>

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -4,6 +4,7 @@
 
 {% block page_content %}
 <h2>Blog</h2>
+<p><a href="/feed.xml">RSS Feed</a></p>
 
 {% for blog in blogs %}
     <a href="{{ blog.url }}">


### PR DESCRIPTION
## Summary
This PR adds RSS feed generation functionality to the website, allowing readers to subscribe to blog posts via their preferred RSS readers.

## Key Changes
- **New `RssJob` class** (`src/Job/RssJob.php`): Implements RSS feed generation by parsing blog markdown files, extracting metadata, and rendering an RSS 2.0 feed
- **RSS feed template** (`templates/blog/feed.xml.twig`): Twig template that generates valid RSS 2.0 XML with proper formatting and CDATA sections for content
- **Job factory registration**: Updated `JobFactory.php` to recognize and instantiate the new `rss` job type
- **RSS configuration** (`jobs/rss.yaml`): Configuration file specifying feed metadata, source path, output location, and base URLs
- **Feed discovery link**: Added RSS feed link to the HTML head in `abstract.html.twig` for automatic feed discovery by browsers and readers

## Implementation Details
- Blog posts are loaded from the configured source directory and parsed using the existing FrontYAML parser
- Feed items are sorted by publication date in descending order (newest first)
- The feed includes proper XML namespacing for Atom extensions and uses CDATA sections to safely embed HTML content
- Configuration supports customizable feed title, description, base URLs, and output path
- The implementation follows the existing job pattern used for blog and error page generation