### PR TITLE
Fix blog listing sort order and add blog link to mobile nav

### DIFF
--- a/src/Job/BlogJob.php
+++ b/src/Job/BlogJob.php
@@ -65,7 +65,7 @@ class BlogJob implements JobInterface
 
         usort(
             $listing,
-            fn($a, $b) => $b["published_at"] <=> $a["published_at"],
+            fn($a, $b) => $a["published_at"] <=> $b["published_at"],
         );
 
         $content = $this->twig->render("blog/index.html.twig", [

--- a/templates/abstract.html.twig
+++ b/templates/abstract.html.twig
@@ -24,6 +24,7 @@
       </li>
 
       <li class="mob mob-hidden"><a href="/">Home</a></li>
+      <li class="mob mob-hidden"><a href="/blog/">Blog</a></li>
       <li class="mob mob-hidden"><a href="/projects.php">Projects</a></li>
       <li class="mob mob-hidden"><a href="/contact.php">Contact</a></li>
      </ul>


### PR DESCRIPTION
## Summary
This PR fixes the blog listing sort order and improves mobile navigation by adding a link to the blog section.

## Changes
- **Blog listing sort order**: Reversed the sort comparison in `BlogJob::renderIndex()` to display blog posts in ascending chronological order (oldest first) instead of descending order (newest first)
- **Mobile navigation**: Added a "Blog" link to the mobile navigation menu in the abstract template, positioned between "Home" and "Projects" for better discoverability

## Implementation Details
The sort order change modifies the comparison operator direction from `$b["published_at"] <=> $a["published_at"]` to `$a["published_at"] <=> $b["published_at"]`, which reverses the chronological ordering of the blog listing.

The mobile navigation link follows the existing pattern and uses the same styling classes (`mob mob-hidden`) as other mobile-only navigation items.