### PR TITLE
Fix blog date field reference in template

### DIFF
--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -9,7 +9,7 @@
     <a href="{{ blog.url }}">
         <div style="width: 100%;">
             <h3>{{ blog.title }}</h3>
-            <p><i>Published at {{ blog.date | date('F j, Y') }}</i></p>
+            <p><i>Published at {{ blog.published_at | date('F j, Y') }}</i></p>
         </div>
     </a>
 {% else %}


### PR DESCRIPTION
## Summary
Updated the blog index template to use the correct property name for the publication date field.

## Changes
- Changed `blog.date` to `blog.published_at` in the blog index template
- This aligns the template with the actual property name used in the blog model/entity

## Details
The template was referencing a `date` property that doesn't exist on the blog object. The correct property name is `published_at`, which is now used to display the publication date in the blog listing page.