### PR TITLE
Replace PHP date function with Twig filter in footer

### DIFF
--- a/templates/abstract.html.twig
+++ b/templates/abstract.html.twig
@@ -41,7 +41,7 @@
     </div>
     <div class="footer">
      <p>
-      &copy; Archey Barrell <?php print(date("Y")); ?>. All Rights Reserved.
+      &copy; Archey Barrell {{ "now"|date("Y") }}. All Rights Reserved.
      </p>
     </dib>
    </div></div>


### PR DESCRIPTION
## Summary
Updated the footer copyright year to use Twig's native date filter instead of inline PHP code, improving template consistency and maintainability.

## Key Changes
- Replaced `<?php print(date("Y")); ?>` with `{{ "now"|date("Y") }}` in the footer copyright notice
- Converts PHP logic to Twig templating syntax for better separation of concerns

## Implementation Details
The change leverages Twig's built-in `date` filter applied to the `"now"` string, which achieves the same result as the PHP `date("Y")` function while maintaining consistency with Twig template conventions. This eliminates the need for embedded PHP code within the template.

https://claude.ai/code/session_011jbXANL2LQvs1aHKSZshdw